### PR TITLE
Fix for url version 0.2.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ doctest = false
 
 hyper = ">= 0.3.15"
 rustc-serialize = ">= 0.3.14"
-url = ">= 0.2.31"
+url = ">= 0.2.32"

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 use hyper::status::StatusCode;
 use rustc_serialize::json;
 use url::{ParseError, Url};
-use url::form_urlencoded::serialize_owned;
+use url::form_urlencoded;
 
 use error::Error;
 use http;
@@ -144,7 +144,7 @@ impl Client {
             options.push(("prevExist".to_string(), format!("{}", prev_exist.unwrap())));
         }
 
-        let body = serialize_owned(&options);
+        let body = form_urlencoded::serialize(&options);
 
         let mut response = try!(http::put(url, body));
         let mut response_body = String::new();


### PR DESCRIPTION
Fix for servo/rust-url#81 removed `serialize_owned` and made `serialize` work generically.