### PR TITLE
Implement leader statistics

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -117,6 +117,10 @@ impl Client {
     }
 
     /// Returns statistics on the leader member of a cluster.
+    ///
+    /// # Failures
+    ///
+    /// Fails if JSON decoding fails, which suggests a bug in our schema.
     pub fn leader_stats(&self) -> Result<LeaderStats, Error> {
         let url = format!("{}v2/stats/leader", self.root_url);
         let mut response = try!(http::get(url));
@@ -124,8 +128,8 @@ impl Client {
         try!(response.read_to_string(&mut response_body));
 
         match response.status {
-            StatusCode::Ok => Ok(try!(json::decode(&response_body))),
-            _ => Err(Error::Etcd(try!(json::decode(&response_body))))
+            StatusCode::Ok => Ok(json::decode(&response_body).unwrap()),
+            _ => Err(Error::Etcd(json::decode(&response_body).unwrap()))
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use std::convert::From;
-
 use hyper::HttpError;
+use std::io::Error as IoError;
+use rustc_serialize::json::DecoderError;
 
 /// An error returned by `Client` when an API call fails.
 #[derive(Debug)]
@@ -9,6 +10,8 @@ pub enum Error {
     Etcd(EtcdError),
     /// An HTTP error from attempting to connect to etcd.
     Http(HttpError),
+    Io(IoError),
+    JsonDecoderError(DecoderError),
 }
 
 /// An error returned by etcd.
@@ -28,5 +31,17 @@ pub struct EtcdError {
 impl From<HttpError> for Error {
     fn from(error: HttpError) -> Error {
         Error::Http(error)
+    }
+}
+
+impl From<IoError> for Error {
+    fn from(error: IoError) -> Error {
+        Error::Io(error)
+    }
+}
+
+impl From<DecoderError> for Error {
+    fn from(error: DecoderError) -> Error {
+        Error::JsonDecoderError(error)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,9 @@ pub enum Error {
     Etcd(EtcdError),
     /// An HTTP error from attempting to connect to etcd.
     Http(HttpError),
+    /// An IO error, which can happen when reading the HTTP response.
     Io(IoError),
+    /// An error that occurs when the JSON response does not match the expected data structure.
     JsonDecoderError(DecoderError),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
 use std::convert::From;
 use hyper::HttpError;
 use std::io::Error as IoError;
-use rustc_serialize::json::DecoderError;
 
 /// An error returned by `Client` when an API call fails.
 #[derive(Debug)]
@@ -12,8 +11,6 @@ pub enum Error {
     Http(HttpError),
     /// An IO error, which can happen when reading the HTTP response.
     Io(IoError),
-    /// An error that occurs when the JSON response does not match the expected data structure.
-    JsonDecoderError(DecoderError),
 }
 
 /// An error returned by etcd.
@@ -39,11 +36,5 @@ impl From<HttpError> for Error {
 impl From<IoError> for Error {
     fn from(error: IoError) -> Error {
         Error::Io(error)
-    }
-}
-
-impl From<DecoderError> for Error {
-    fn from(error: DecoderError) -> Error {
-        Error::JsonDecoderError(error)
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use error::Error;
 
 /// Returned by `Client` API calls. A result containing an etcd `Response` or an `Error`.
@@ -35,4 +36,41 @@ pub struct Node {
     pub ttl: Option<i64>,
     /// The value of the key.
     pub value: Option<String>,
+}
+
+/// Statistics about an etcd cluster leader.
+#[derive(Clone, Debug, RustcDecodable)]
+#[allow(non_snake_case)]
+pub struct LeaderStats {
+    /// A unique identifier of a leader member.
+    pub leader: String,
+    /// Statistics for each peer in the cluster keyed by each peer's unique identifier.
+    pub followers: HashMap<String, FollowerStats>,
+}
+
+/// Statistics on the health of a single follower.
+#[derive(Clone, Debug, RustcDecodable)]
+#[allow(non_snake_case)]
+pub struct FollowerStats {
+    /// Counts of Raft RPC request successes and failures to this follower.
+    pub counts: Option<CountStats>,
+    /// Latency statistics for this follower.
+    pub latency: Option<LatencyStats>,
+}
+
+#[derive(Clone, Debug, RustcDecodable)]
+#[allow(non_snake_case)]
+pub struct CountStats {
+    pub fail: Option<u64>,
+    pub success: Option<u64>,
+}
+
+#[derive(Clone, Debug, RustcDecodable)]
+#[allow(non_snake_case)]
+pub struct LatencyStats {
+    pub average: Option<f64>,
+    pub current: Option<f64>,
+    pub maximum: Option<f64>,
+    pub minimum: Option<f64>,
+    pub standardDeviation: Option<f64>,
 }

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -100,3 +100,10 @@ fn lifecycle() {
     client.delete("/dir/baz", false).ok();
     client.delete_dir("/dir").ok();
 }
+
+#[test]
+fn leader_stats() {
+    let client = Client::new("http://etcd:2379").unwrap();
+
+    client.leader_stats().unwrap();
+}


### PR DESCRIPTION
Implementation of the [leader statistics API](https://github.com/coreos/etcd/blob/master/Documentation/api.md#leader-statistics).

Curious if you think this is the right approach for this. I'm a bit wary that it encodes the current API for these statistics too statically. Alternatively, it could expose something more like the [Json object](http://doc.rust-lang.org/rustc-serialize/rustc_serialize/json/enum.Json.html) itself, which can be queried dynamically.

Also curious if you think the `leader_stats` method on `Client` is the right place/name for this.

Note that I added a couple error types: an IO error, which can happen when reading the response into a string, and a JSON decoding error, which happens if the response doesn't match the expected data structure. Let me know if you like that approach and I'll change the other methods that currently panic in those cases; if not, I can make this consistent with everything else.