### PR TITLE
Pull JSON decoding into a method in the http module

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,8 +1,5 @@
 use std::collections::HashMap;
-use std::io::Read;
 
-use hyper::status::StatusCode;
-use rustc_serialize::json;
 use url::{ParseError, Url};
 use url::form_urlencoded;
 
@@ -87,14 +84,8 @@ impl Client {
         let mut url = Url::parse(&base_url[..]).unwrap();
         url.set_query_from_pairs(query_pairs.iter().map(|(k, v)| (*k, *v)));
 
-        let mut response = try!(http::get(format!("{}", url)));
-        let mut response_body = String::new();
-        response.read_to_string(&mut response_body).unwrap();
-
-        match response.status {
-            StatusCode::Ok => Ok(json::decode(&response_body).unwrap()),
-            _ => Err(Error::Etcd(json::decode(&response_body).unwrap())),
-        }
+        let response = try!(http::get(format!("{}", url)));
+        http::decode(response)
     }
 
     /// Sets the key to the given value with the given time to live in seconds. Any previous value
@@ -123,14 +114,8 @@ impl Client {
     /// Fails if JSON decoding fails, which suggests a bug in our schema.
     pub fn leader_stats(&self) -> Result<LeaderStats, Error> {
         let url = format!("{}v2/stats/leader", self.root_url);
-        let mut response = try!(http::get(url));
-        let mut response_body = String::new();
-        try!(response.read_to_string(&mut response_body));
-
-        match response.status {
-            StatusCode::Ok => Ok(json::decode(&response_body).unwrap()),
-            _ => Err(Error::Etcd(json::decode(&response_body).unwrap()))
-        }
+        let response = try!(http::get(url));
+        http::decode(response)
     }
 
     // private
@@ -164,14 +149,8 @@ impl Client {
         let mut url = Url::parse(&base_url[..]).unwrap();
         url.set_query_from_pairs(query_pairs.iter().map(|(k, v)| (*k, *v)));
 
-        let mut response = try!(http::delete(format!("{}", url)));
-        let mut response_body = String::new();
-        response.read_to_string(&mut response_body).unwrap();
-
-        match response.status {
-            StatusCode::Ok => Ok(json::decode(&response_body).unwrap()),
-            _ => Err(Error::Etcd(json::decode(&response_body).unwrap())),
-        }
+        let response = try!(http::delete(format!("{}", url)));
+        http::decode(response)
     }
 
     /// Handles all set operations.
@@ -204,13 +183,7 @@ impl Client {
 
         let body = form_urlencoded::serialize(&options);
 
-        let mut response = try!(http::put(url, body));
-        let mut response_body = String::new();
-        response.read_to_string(&mut response_body).unwrap();
-
-        match response.status {
-            StatusCode::Created | StatusCode::Ok => Ok(json::decode(&response_body).unwrap()),
-            _ => Err(Error::Etcd(json::decode(&response_body).unwrap())),
-        }
+        let response = try!(http::put(url, body));
+        http::decode(response)
     }
 }


### PR DESCRIPTION
This is an idea I had while going through and using `try!` everywhere we're reading the response into a string in order to propagate IO errors instead of panicking. It works well, but a potential downside is that it accepts `StatusCode::Created` as a successful response code for all requests, rather than just for "set" operations as before. Not sure whether or not that's a dealbreaker for this approach.

(Based on #2.)