### PR TITLE
Lock dependencies of serde et al.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,22 +13,22 @@ version = "0.5.4"
 
 [build-dependencies.serde_codegen]
 optional = true
-version = "0.7.7"
+version = "=0.7.7"
 
 [build-dependencies.syntex]
 optional = true
-version = "0.33.0"
+version = "=0.33.0"
 
 [dependencies]
 hyper = "0.8.1"
 openssl = "0.7.13"
-serde = "0.7.7"
-serde_json = "0.7.1"
+serde = "=0.7.7"
+serde_json = "=0.7.1"
 url = "0.5.9"
 
 [dependencies.serde_macros]
 optional = true
-version = "0.7.7"
+version = "=0.7.7"
 
 [features]
 default = ["serde_codegen", "syntex"]


### PR DESCRIPTION
Seems that Cargo will `consider a requirement string without a prefixed operator equivalent to prefixing a carot: 1.2.3 == ^1.2.3`.

https://github.com/rust-lang/cargo/issues/1418
https://github.com/steveklabnik/semver/issues/81

As for the 'semver patches shouldn't break things' argument, https://github.com/serde-rs/serde/issues/379