### PR TITLE
Fix compilation error due to syntex mismatched types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.5.4"
 
 [build-dependencies.serde_codegen]
 optional = true
-version = "0.7.7"
+version = "0.7.12"
 
 [build-dependencies.syntex]
 optional = true

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,6 @@
 #[cfg(not(feature = "serde_macros"))]
 mod inner {
     extern crate serde_codegen;
-    extern crate syntex;
 
     use std::env;
     use std::path::Path;
@@ -22,10 +21,7 @@ mod inner {
             let dst = format!("{}.rs", module);
             let dst_path = Path::new(&out_dir).join(&dst);
 
-            let mut registry = syntex::Registry::new();
-
-            serde_codegen::register(&mut registry);
-            registry.expand("", &src_path, &dst_path).unwrap();
+            serde_codegen::expand(&src_path, &dst_path).unwrap();
         }
     }
 }


### PR DESCRIPTION
Error:
```
build.rs:27:37: 27:50 error: mismatched types:
expected `&mut syntex::Registry`,
found `&mut inner::syntex::Registry`
(expected struct `syntex::Registry`,
found struct `inner::syntex::Registry`) [E0308]
build.rs:27             serde_codegen::register(&mut registry);
                                            ^~~~~~~~~~~~~
```

Solution is to use codegen without explicit dependency on syntex, see:
https://users.rust-lang.org/t/here-is-how-to-avoid-being-broken-by-syntex-updates/6189?u=dtolnay