### PR TITLE
Dependencies upgraded to latest available version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,28 +8,31 @@ license = "MIT"
 name = "etcd"
 readme = "README.md"
 repository = "https://github.com/jimmycuadra/rust-etcd"
-version = "0.8.0"
+version = "0.9.0"
 
 [lib]
 test = false
 
 [dependencies]
-futures = "0.1.14"
-hyper = "0.11.19"
-serde = "1.0.9"
-serde_derive = "1.0.9"
-serde_json = "1.0.2"
-tokio-core = "0.1.8"
-tokio-timer = "0.1.2"
-url = "1.5.1"
+futures = "0.1.25"
+hyper = "0.12.13"
+http = "0.1.13"
+serde = "1.0.80"
+serde_derive = "1.0.80"
+serde_json = "1.0.32"
+tokio-core = "0.1.17"
+tokio-timer = "0.2.7"
+url = "1.7.1"
+base64 = "0.10.0"
+log = "0.4.6"
 
 [dependencies.hyper-tls]
 optional = true
-version = "0.1.2"
+version = "0.3.1"
 
 [dependencies.native-tls]
 optional = true
-version = "0.1.4"
+version = "0.2.2"
 
 [features]
 default = ["tls"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - ./tests/ssl:/ssl
   rust:
-    image: rust:1.24.0
+    image: rust:1.26.0
     environment:
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,11 +5,11 @@ use std::error::Error as StdError;
 use std::fmt::{Display, Error as FmtError, Formatter};
 
 use hyper::{Error as HttpError, StatusCode};
-use hyper::error::UriError;
+use hyper_http::uri::InvalidUri;
 #[cfg(feature = "tls")]
 use native_tls::Error as TlsError;
 use serde_json::Error as SerializationError;
-use tokio_timer::TimeoutError as TokioTimeoutError;
+use tokio_timer::timeout::Error as TokioTimeoutError;
 use url::ParseError as UrlError;
 
 /// An error returned by an etcd API endpoint.
@@ -52,7 +52,7 @@ pub enum Error {
     /// compare-and-swap operation.
     InvalidConditions,
     /// An error returned when an etcd cluster member's endpoint is not a valid URI.
-    InvalidUri(UriError),
+    InvalidUri(InvalidUri),
     /// An error returned when the URL for a specific API endpoint cannot be generated.
     InvalidUrl(UrlError),
     /// An error returned when attempting to create a client without at least one member endpoint.
@@ -129,8 +129,8 @@ impl From<SerializationError> for Error {
     }
 }
 
-impl From<UriError> for Error {
-    fn from(error: UriError) -> Error {
+impl From<InvalidUri> for Error {
+    fn from(error: InvalidUri) -> Error {
         Error::InvalidUri(error)
     }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -28,7 +28,7 @@ use url::form_urlencoded::Serializer;
 ///
 /// On success, information about the result of the operation and information about the etcd
 /// cluster. On failure, an error for each cluster member that failed.
-pub type FutureKeyValueInfo = Box<Future<Item = Response<KeyValueInfo>, Error = Vec<Error>>>;
+pub type FutureKeyValueInfo = Box<Future<Item = Response<KeyValueInfo>, Error = Vec<Error>> + Send>;
 
 /// Information about the result of a successful key-value API operation.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
@@ -510,7 +510,7 @@ pub fn watch<C>(
     client: &Client<C>,
     key: &str,
     options: WatchOptions,
-) -> Box<Future<Item = Response<KeyValueInfo>, Error = WatchError>>
+) -> Box<Future<Item = Response<KeyValueInfo>, Error = WatchError> + Send>
 where
     C: Clone + Connect,
 {

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -11,9 +11,9 @@ use std::time::Duration;
 use futures::future::{Future, IntoFuture};
 use futures::stream::Stream;
 use hyper::{StatusCode, Uri};
-use hyper::client::Connect;
+use hyper::client::connect::Connect;
 use serde_json;
-use tokio_timer::Timer;
+use tokio_timer::Timeout;
 use url::Url;
 
 pub use error::WatchError;
@@ -526,9 +526,11 @@ where
     ).map_err(|errors| WatchError::Other(errors));
 
     if let Some(duration) = options.timeout {
-        let timer = Timer::default();
-
-        Box::new(timer.timeout(work, duration))
+        Box::new(Timeout::new(work, duration)
+                        .map_err(|e| match e.into_inner() {
+                            Some(we) => we,
+                            None => WatchError::Timeout,
+                        }))
     } else {
         Box::new(work)
     }
@@ -594,9 +596,9 @@ where
         let result = response.and_then(move |response| {
             let status = response.status();
             let cluster_info = ClusterInfo::from(response.headers());
-            let body = response.body().concat2().map_err(Error::from);
+            let body = response.into_body().concat2().map_err(Error::from);
 
-            body.and_then(move |ref body| if status == StatusCode::Ok {
+            body.and_then(move |ref body| if status == StatusCode::OK {
                 match serde_json::from_slice::<KeyValueInfo>(body) {
                     Ok(data) => Ok(Response { data, cluster_info }),
                     Err(error) => Err(Error::Serialization(error)),
@@ -657,9 +659,9 @@ where
         let result = response.and_then(|response| {
             let status = response.status();
             let cluster_info = ClusterInfo::from(response.headers());
-            let body = response.body().concat2().map_err(Error::from);
+            let body = response.into_body().concat2().map_err(Error::from);
 
-            body.and_then(move |ref body| if status == StatusCode::Ok {
+            body.and_then(move |ref body| if status == StatusCode::OK {
                 match serde_json::from_slice::<KeyValueInfo>(body) {
                     Ok(data) => Ok(Response { data, cluster_info }),
                     Err(error) => Err(Error::Serialization(error)),
@@ -740,10 +742,10 @@ where
         let result = response.and_then(|response| {
             let status = response.status();
             let cluster_info = ClusterInfo::from(response.headers());
-            let body = response.body().concat2().map_err(Error::from);
+            let body = response.into_body().concat2().map_err(Error::from);
 
             body.and_then(move |ref body| match status {
-                StatusCode::Created | StatusCode::Ok => {
+                StatusCode::CREATED | StatusCode::OK => {
                     match serde_json::from_slice::<KeyValueInfo>(body) {
                         Ok(data) => Ok(Response { data, cluster_info }),
                         Err(error) => Err(Error::Serialization(error)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,13 +40,11 @@
 //! fn main() {
 //!     // Create a `Core`, which is the event loop which will drive futures to completion.
 //!     let mut core = Core::new().unwrap();
-//!     // Get a "handle" to the event loop that the client can use to schedule work.
-//!     let handle = core.handle();
 //!
 //!     // Create a client to access a single cluster member. Addresses of multiple cluster
 //!     // members can be provided and the client will try each one in sequence until it
 //!     // receives a successful response.
-//!     let client = Client::new(&handle, &["http://etcd.example.com:2379"], None).unwrap();
+//!     let client = Client::new(&["http://etcd.example.com:2379"], None).unwrap();
 //!
 //!     // Set the key "/foo" to the value "bar" with no expiration.
 //!     let work = kv::set(&client, "/foo", "bar", None).and_then(|_| {
@@ -80,8 +78,9 @@
 #![deny(missing_debug_implementations, missing_docs, warnings)]
 
 extern crate futures;
-#[macro_use]
+// #[macro_use]
 extern crate hyper;
+extern crate http as hyper_http;
 #[cfg(feature = "tls")]
 extern crate hyper_tls;
 #[cfg(feature = "tls")]
@@ -93,6 +92,9 @@ extern crate serde_json;
 extern crate tokio_core;
 extern crate tokio_timer;
 extern crate url;
+extern crate base64;
+#[macro_use]
+extern crate log;
 
 pub use client::{BasicAuth, Client, ClusterInfo, Health, Response};
 pub use error::{ApiError, Error};

--- a/src/members.rs
+++ b/src/members.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use futures::{Future, IntoFuture, Stream};
 use hyper::{StatusCode, Uri};
-use hyper::client::Connect;
+use hyper::client::connect::Connect;
 use serde_json;
 
 use async::first_ok;
@@ -79,9 +79,9 @@ where
         let result = response.and_then(|response| {
             let status = response.status();
             let cluster_info = ClusterInfo::from(response.headers());
-            let body = response.body().concat2().map_err(Error::from);
+            let body = response.into_body().concat2().map_err(Error::from);
 
-            body.and_then(move |ref body| if status == StatusCode::Created {
+            body.and_then(move |ref body| if status == StatusCode::CREATED {
                 Ok(Response {
                     data: (),
                     cluster_info,
@@ -128,9 +128,9 @@ where
         let result = response.and_then(|response| {
             let status = response.status();
             let cluster_info = ClusterInfo::from(response.headers());
-            let body = response.body().concat2().map_err(Error::from);
+            let body = response.into_body().concat2().map_err(Error::from);
 
-            body.and_then(move |ref body| if status == StatusCode::NoContent {
+            body.and_then(move |ref body| if status == StatusCode::NO_CONTENT {
                 Ok(Response {
                     data: (),
                     cluster_info,
@@ -172,9 +172,9 @@ where
         let result = response.and_then(|response| {
             let status = response.status();
             let cluster_info = ClusterInfo::from(response.headers());
-            let body = response.body().concat2().map_err(Error::from);
+            let body = response.into_body().concat2().map_err(Error::from);
 
-            body.and_then(move |ref body| if status == StatusCode::Ok {
+            body.and_then(move |ref body| if status == StatusCode::OK {
                 match serde_json::from_slice::<ListResponse>(body) {
                     Ok(data) => Ok(Response {
                         data: data.members,
@@ -234,9 +234,9 @@ where
         let result = response.and_then(|response| {
             let status = response.status();
             let cluster_info = ClusterInfo::from(response.headers());
-            let body = response.body().concat2().map_err(Error::from);
+            let body = response.into_body().concat2().map_err(Error::from);
 
-            body.and_then(move |ref body| if status == StatusCode::NoContent {
+            body.and_then(move |ref body| if status == StatusCode::NO_CONTENT {
                 Ok(Response {
                     data: (),
                     cluster_info,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use futures::{Future, IntoFuture, Stream};
 use futures::stream::futures_unordered;
 use hyper::Uri;
-use hyper::client::Connect;
+use hyper::client::connect::Connect;
 
 use client::{Client, Response};
 use error::Error;

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -14,7 +14,7 @@ use etcd::auth::{self, AuthChange, NewUser, Role, RoleUpdate, UserUpdate};
 #[test]
 fn auth() {
     let mut core = Core::new().unwrap();
-    let client = Client::new(&core.handle(), &["http://etcd:2379"], None).unwrap();
+    let client = Client::new(&["http://etcd:2379"], None).unwrap();
 
     let basic_auth = BasicAuth {
         username: "root".into(),
@@ -22,7 +22,7 @@ fn auth() {
     };
 
     let authed_client =
-        Client::new(&core.handle(), &["http://etcd:2379"], Some(basic_auth)).unwrap();
+        Client::new(&["http://etcd:2379"], Some(basic_auth)).unwrap();
 
     let root_user = NewUser::new("root", "secret");
 


### PR DESCRIPTION
I upgraded all deps, with new hyper version we are no more forced to carry around a tokio core handler reference.
The only stylistic doubt I have is about _impl From for Clusterinfo_, the conversion from String can fail, From can't fail, so I've used log crate to log the failure without panic-ing...